### PR TITLE
Update URL in addBezierCurve

### DIFF
--- a/lib/Path/BoundingBox.js
+++ b/lib/Path/BoundingBox.js
@@ -59,7 +59,7 @@ BoundingBox.prototype = {
   },
 
   addBezierCurve: function (p0x, p0y, p1x, p1y, p2x, p2y, p3x, p3y) {
-    // from http://blog.hackers-cafe.net/2009/06/how-to-calculate-bezier-curves-bounding.html
+    // from http://nishiohirokazu.blogspot.com/2009/06/how-to-calculate-bezier-curves-bounding.html
     var
       i,
       p0 = [p0x, p0y],


### PR DESCRIPTION
The old URL in addBezierCurve has expired, and the domain is now for sale. I've updated the link to point to the new blog.